### PR TITLE
fix wrong info in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ There is a tutorial for getting started from scratch uploading code to OpenBCI 3
 
 Note that to USE the OpenBCI system, you will generally use the OpenBCI USB Dongle. The dongle requries that you install the FTDI drivers for your particular operating system: http://www.ftdichip.com/FTDrivers.htm
 
-Download Arduino IDE version 1.6.5 software from the Arduino site. Currently, only 1.6.5 works with our software.
+Download Arduino IDE version 1.6.12 software from the Arduino site.
 https://www.arduino.cc/en/Main/OldSoftwareReleases#previous
 
 Follow the instructions to download and install the latest chipKIT-core hardware files from the chipKIT-core wiki 


### PR DESCRIPTION
See https://github.com/OpenBCI/OpenBCI_32bit_Library/issues/46#issuecomment-276713249 for discussion.  The summary is that 1.6.5 does NOT work, but 1.6.12 does (possibly other versions work too, but I only tried 1.6.12).